### PR TITLE
Add support for GNOME Shell 48

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -6,11 +6,15 @@
    Contains some code from All Windows extension by lyonel
 */
 
-const { Gio, GObject, St, Shell } = imports.gi;
-const Main = imports.ui.main;
-const Meta = imports.gi.Meta;
-const Me = imports.misc.extensionUtils.getCurrentExtension();
-const Direction = Me.imports.utils.settings.Direction;
+import GObject from 'gi://GObject';
+import St from 'gi://St';
+import Shell from 'gi://Shell';
+import Mtk from 'gi://Mtk';
+
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+
+import {Direction} from './utils/settings.js';
 
 const ICON_SIZE = 22;
 
@@ -86,7 +90,7 @@ const WindowList = GObject.registerClass(
                 this.box.icon = this.app.create_icon_texture(ICON_SIZE);
                 this.box.style_class = 'focused-app';
                 this.box.set_child(this.box.icon);
-                this.apps_menu.add_actor(this.box);
+                this.apps_menu.add_child(this.box);
             }
         }
 
@@ -97,7 +101,7 @@ const WindowList = GObject.registerClass(
             const anchor = this.side.anchor(width);
             if (this.area?.x !== anchor)
                 // Avoid creating too much rectangles
-                this.area = new Meta.Rectangle({
+                this.area = new Mtk.Rectangle({
                     x: anchor,
                     y: 0,
                     width: ICON_SIZE,
@@ -139,12 +143,14 @@ const WindowList = GObject.registerClass(
     }
 );
 
-class Extension {
-    constructor() {}
+export default class MinimizeShelfExtension extends Extension {
+    constructor(metadata) {
+        super(metadata);
+    }
 
     enable() {
-        Side = new Direction().load();
-        this.eventhandler = Side.settings.connect('changed', this._reload);
+        Side = new Direction(this.getSettings()).load();
+        this.eventhandler = Side.settings.connect('changed', this._reload.bind(this));
 
         this.windowlist = new WindowList(Side);
         this.windowlist._insert();
@@ -156,10 +162,6 @@ class Extension {
     }
 
     _reload() {
-        Main.extensionManager.reloadExtension(Me);
+        Main.extensionManager.reloadExtension(this);
     }
-}
-
-function init() {
-    return new Extension();
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,18 +1,11 @@
 {
   "description": "Minimize shelf in the top panel, with minimized windows of the current workspace.\n\n No settings but you can easily play around with CSS file. This extension is light and should not interfere with GNOME Shell behaviour+logic.",
   "name": "Minimize Shelf",
+  "settings-schema": "org.gnome.shell.extensions.minimize-shelf",
   "shell-version": [
-    "3.30",
-    "3.32",
-    "3.34",
-    "3.36",
-    "40",
-    "41",
-    "42",
-    "43",
-    "44"
+    "48"
   ],
   "url": "https://github.com/batisteo/minimize-shelf",
   "uuid": "minimize-shelf@etenil",
-  "version": 11
+  "version": 12
 }

--- a/prefs.js
+++ b/prefs.js
@@ -1,9 +1,10 @@
-const Gio = imports.gi.Gio;
-const GObject = imports.gi.GObject;
-const Gtk = imports.gi.Gtk;
+import GObject from 'gi://GObject';
+import Gtk from 'gi://Gtk';
+import Adw from 'gi://Adw';
 
-const Me = imports.misc.extensionUtils.getCurrentExtension();
-const Direction = Me.imports.utils.settings.Direction;
+import {ExtensionPreferences} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+
+import {Direction} from './utils/settings.js';
 
 const _toggle_direction = widget => {
     if (widget.get_active()) Side.save(Side[widget.label]);
@@ -45,10 +46,16 @@ const PrefsWidget = GObject.registerClass(
     }
 );
 
-function init() {
-    Side = new Direction().load();
-}
-
-function buildPrefsWidget() {
-    return new PrefsWidget({ margin_top: 200, margin_side: 160 });
+export default class MinimizeShelfPreferences extends ExtensionPreferences {
+    fillPreferencesWindow(window) {
+        Side = new Direction(this.getSettings()).load();
+        
+        const page = new Adw.PreferencesPage();
+        const group = new Adw.PreferencesGroup();
+        
+        const prefsWidget = new PrefsWidget({ margin_top: 200, margin_side: 160 });
+        group.add(prefsWidget);
+        page.add(group);
+        window.add(page);
+    }
 }

--- a/utils/settings.js
+++ b/utils/settings.js
@@ -1,13 +1,8 @@
-const Gio = imports.gi.Gio;
-
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-
-var Direction = class Direction {
-    constructor() {
+export class Direction {
+    constructor(settings) {
         this.Left = 0;
         this.Right = 1;
-        this.settings = getSettings();
+        this.settings = settings;
     }
     get value() {
         return this._value;
@@ -40,18 +35,4 @@ var Direction = class Direction {
         this.settings.set_enum('direction', value);
         this.value = value;
     }
-};
-
-function getSettings() {
-    let schemaSource = Gio.SettingsSchemaSource.new_from_directory(
-        Me.dir.get_child('schemas').get_path(),
-        Gio.SettingsSchemaSource.get_default(),
-        false
-    );
-    let schemaObj = schemaSource.lookup(
-        'org.gnome.shell.extensions.minimize-shelf',
-        true
-    );
-    if (!schemaObj) throw new Error('Minimize-shelf: cannot find schemas');
-    return new Gio.Settings({ settings_schema: schemaObj });
 }


### PR DESCRIPTION
- Update metadata.json to support GNOME Shell 48
- Support for older GNOME Shell versions removed as I have no effective way to test the new code with older versions.
- Modernize extension.js with ES6 imports and new Extension class
- Update prefs.js to use ExtensionPreferences with Adw widgets
- Pass settings instance into utils/settings.js as dependency